### PR TITLE
Add Kernel on Runloop browser example (Python + TypeScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please refer to the [Runloop documentation site](https://docs.runloop.ai) for mo
     - [Devbox Primitives](#devbox-primitives)
     - [Axons \& Broker](#axons--broker)
     - [Add-ons](#add-ons)
+    - [Browser Integrations](#browser-integrations)
     - [LLM \& Framework integrations](#llm--framework-integrations)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -60,6 +61,14 @@ These examples show you how to use add-ons which extend the core Runloop platfor
 | **Browser Control** | Control web browsers and automate web tasks | [`runloop-demo-browser/`](runloop-demo-browser/) |
 | **Computer Control** | Interact with the local computer system | [`runloop-demo-computer/`](runloop-demo-computer/) |
 | **OpenClaw** | Securely run OpenClaw inside Runloop Devboxes, including a parallel-execution example | [`openclaw/`](openclaw/) |
+
+### Browser Integrations
+
+Drive third-party cloud browser providers from Runloop devboxes. The agent runs in a devbox; the browser runs on the provider, so no Chromium runs in the devbox.
+
+| Provider | Description | Python | TypeScript |
+|----------|-------------|---------|------------|
+| **Kernel** | [Kernel](https://www.kernel.sh) cloud browsers driven server-side via Playwright Execute | [`browser-integrations/kernel/python/`](browser-integrations/kernel/python/) | [`browser-integrations/kernel/typescript/`](browser-integrations/kernel/typescript/) |
 
 ### LLM & Framework integrations
 

--- a/browser-integrations/kernel/.env.example
+++ b/browser-integrations/kernel/.env.example
@@ -1,0 +1,5 @@
+# Runloop devbox API key: https://platform.runloop.ai/settings#api-keys
+RUNLOOP_API_KEY=your-runloop-api-key-here
+
+# Kernel cloud browser API key: https://www.kernel.sh
+KERNEL_API_KEY=your-kernel-api-key-here

--- a/browser-integrations/kernel/.gitignore
+++ b/browser-integrations/kernel/.gitignore
@@ -1,0 +1,4 @@
+# Run outputs
+report.json
+screenshots/
+e2e-screenshot.png

--- a/browser-integrations/kernel/.gitignore
+++ b/browser-integrations/kernel/.gitignore
@@ -1,4 +1,3 @@
 # Run outputs
 report.json
 screenshots/
-e2e-screenshot.png

--- a/browser-integrations/kernel/README.md
+++ b/browser-integrations/kernel/README.md
@@ -1,0 +1,36 @@
+# Kernel on Runloop
+
+Give a Runloop agent browser access with [Kernel](https://www.kernel.sh): the agent runs in a devbox, the browser runs on Kernel, and the devbox drives it server-side with Playwright Execute, so no Chromium ever runs in the devbox.
+
+This is the runnable companion to the [Kernel on Runloop](https://docs.runloop.ai/docs/tutorials/kernel-runloop) tutorial and cookbook recipes.
+
+## What's here
+
+A **research crawl** (`run`), in both Python and TypeScript: a research agent inside a devbox drives one Kernel browser to scan seed sites and bring back structured data plus screenshots.
+
+| Language | Location | Run |
+|----------|----------|-----|
+| Python | [`python/`](python/) | `python main.py {create-blueprint \| run}` |
+| TypeScript | [`typescript/`](typescript/) | `npm run {create-blueprint \| run-kernel}` |
+
+## Setup
+
+Both versions need two API keys:
+
+```bash
+cp .env.example .env   # fill in your keys, then export them (or export directly)
+export RUNLOOP_API_KEY="your-key"
+export KERNEL_API_KEY="your-key"
+```
+
+- `RUNLOOP_API_KEY`: provisions and drives the devbox ([platform.runloop.ai](https://platform.runloop.ai/settings#api-keys))
+- `KERNEL_API_KEY`: injected into the devbox to reach Kernel ([kernel.sh](https://www.kernel.sh))
+
+See the per-language READMEs for full instructions.
+
+## How it works
+
+1. `create-blueprint` builds (or reuses) a blueprint that bakes the Kernel SDK into a devbox image, so devboxes start ready.
+2. A run provisions a devbox with a bounded wait: a stuck provision fails fast and is cleaned up, instead of hanging.
+3. The agent calls `browsers.create()` for a Kernel cloud browser session, then drives it with `browsers.playwright.execute()`: Playwright code runs co-located with the browser on Kernel and returns structured data. No CDP, no local browser.
+4. The report and screenshots come back as files, and the devbox is torn down.

--- a/browser-integrations/kernel/python/README.md
+++ b/browser-integrations/kernel/python/README.md
@@ -1,0 +1,45 @@
+# Kernel on Runloop: Python
+
+Drive [Kernel](https://www.kernel.sh) cloud browsers from [Runloop](https://runloop.ai) devboxes. The agent runs in a devbox; the browser runs on Kernel, driven server-side with Playwright Execute, so no Chromium runs in the devbox.
+
+## Setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+export RUNLOOP_API_KEY="your-key"
+export KERNEL_API_KEY="your-key"
+```
+
+## Usage
+
+```bash
+python main.py create-blueprint   # one time (reused on later runs)
+python main.py run                 # research crawl
+```
+
+### Commands
+
+| Command | Description |
+| --- | --- |
+| `create-blueprint [--rebuild]` | Reuse an existing built blueprint, or build one. `--rebuild` forces a fresh build. |
+| `run [--manual] [--snapshot]` | Research crawl. `--manual` installs the Kernel SDK at runtime; `--snapshot` snapshots the disk on success. |
+
+## Layout
+
+- `main.py`: CLI entry point.
+- The `kernel_runloop/` package:
+  - `config`: blueprint definition, crawl targets, and the in-devbox agent loader.
+  - `create_blueprint`: idempotent blueprint build/reuse.
+  - `run_kernel`: the research crawl orchestrator.
+  - `agent`: the in-devbox crawl agent, uploaded and run with `python3`.
+  - `provision`: bounded devbox provisioning (fail fast on a stuck provision).
+  - `status`: progress output.
+
+## How it works
+
+1. `create-blueprint` builds (or reuses) a blueprint that bakes the Kernel SDK into a devbox image.
+2. A run provisions a devbox with a bounded wait: a stuck provision fails fast and is cleaned up.
+3. The agent drives a Kernel browser with `browsers.playwright.execute()`: Playwright runs co-located with the browser on Kernel and returns structured data. No CDP, no local browser.
+4. `run` writes a report plus screenshots and tears the devbox down.

--- a/browser-integrations/kernel/python/kernel_runloop/__init__.py
+++ b/browser-integrations/kernel/python/kernel_runloop/__init__.py
@@ -1,0 +1,14 @@
+"""Kernel on Runloop: drive Kernel cloud browsers from Runloop devboxes."""
+
+from .config import BLUEPRINT_NAME, DEFAULT_TARGETS
+from .create_blueprint import create_kernel_blueprint
+from .run_kernel import RunKernelOptions, RunKernelResult, run_kernel
+
+__all__ = [
+    "BLUEPRINT_NAME",
+    "DEFAULT_TARGETS",
+    "RunKernelOptions",
+    "RunKernelResult",
+    "create_kernel_blueprint",
+    "run_kernel",
+]

--- a/browser-integrations/kernel/python/kernel_runloop/__main__.py
+++ b/browser-integrations/kernel/python/kernel_runloop/__main__.py
@@ -1,0 +1,36 @@
+"""Command-line entry point.
+
+    kernel-runloop create-blueprint [--rebuild]   reuse or build the Kernel blueprint
+    kernel-runloop run [--manual] [--snapshot]    run the research crawl
+"""
+
+import sys
+
+from .create_blueprint import create_kernel_blueprint
+from .run_kernel import RunKernelOptions, run_kernel
+
+USAGE = "Usage: kernel-runloop {create-blueprint [--rebuild] | run [--manual] [--snapshot]}"
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    command = args[0] if args else ""
+    flags = args[1:]
+
+    if command == "create-blueprint":
+        blueprint_id = create_kernel_blueprint(rebuild="--rebuild" in flags)
+        print(f"Blueprint ready: {blueprint_id}")
+    elif command == "run":
+        result = run_kernel(
+            RunKernelOptions(manual="--manual" in flags, snapshot="--snapshot" in flags)
+        )
+        print(f"Devbox {result.devbox_id} crawled {result.pages_visited} pages")
+        print(f"Report: {result.report_path}")
+        if result.live_view_url:
+            print(f"Live view: {result.live_view_url}")
+    else:
+        print(USAGE)
+
+
+if __name__ == "__main__":
+    main()

--- a/browser-integrations/kernel/python/kernel_runloop/__main__.py
+++ b/browser-integrations/kernel/python/kernel_runloop/__main__.py
@@ -29,7 +29,8 @@ def main() -> None:
         if result.live_view_url:
             print(f"Live view: {result.live_view_url}")
     else:
-        print(USAGE)
+        print(USAGE, file=sys.stderr)
+        raise SystemExit(2)
 
 
 if __name__ == "__main__":

--- a/browser-integrations/kernel/python/kernel_runloop/agent.py
+++ b/browser-integrations/kernel/python/kernel_runloop/agent.py
@@ -1,0 +1,227 @@
+"""In-devbox research agent.
+
+This module is uploaded into a Runloop devbox and run there (it is not imported
+by the rest of the package). It drives a single Kernel cloud browser via
+Playwright Execute to crawl a set of seed sites two levels deep, extracting
+structured data and a homepage screenshot per seed. Configuration is read from
+the environment, and results are written to files (no stdout protocol):
+
+    TARGETS         JSON list of {"name", "url"}
+    LINKS_PER_SEED  level-1 internal links followed per seed (default 8)
+    DEPTH           crawl depth, 1 or 2 (default 2)
+    LEVEL2_PARENTS  how many level-1 pages to expand into level 2 (default 2)
+    LEVEL2_LINKS    level-2 links per expanded parent (default 3)
+
+Outputs:
+    /home/user/result/report.json    full structured report
+    /home/user/result/summary.json   compact summary
+    /home/user/shots/<seed>.png      one homepage screenshot per seed
+"""
+
+import json
+import os
+import time
+from urllib.parse import urlparse
+
+from kernel import Kernel
+
+RESULT_DIR = "/home/user/result"
+SHOTS_DIR = "/home/user/shots"
+
+# Link paths we never follow (auth flows and non-content endpoints).
+SKIP_SEGMENTS = {
+    "login", "signin", "sign-in", "signup", "sign-up", "logout", "sign-out",
+    "account", "auth", "oauth", "cart", "checkout", "register", "admin",
+}
+SKIP_SUFFIXES = (".txt", ".xml", ".json", ".pdf", ".zip", ".png", ".jpg", ".svg", ".rss", ".ico")
+
+# Playwright snippet (JavaScript) run server-side on Kernel. It navigates, waits
+# for the network to settle so client-rendered content is present, then returns
+# structured data. `__URL__` is replaced per call.
+EXTRACT_JS = r"""
+await page.goto(__URL__, { waitUntil: "domcontentloaded", timeout: 20000 });
+await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+return await page.evaluate(() => {
+  const clean = (s) => (s || "").replace(/\s+/g, " ").trim();
+  const meta = document.querySelector('meta[name="description"]');
+  const here = location.origin;
+  const links = [];
+  const seen = new Set();
+  for (const a of document.querySelectorAll("a[href]")) {
+    let u;
+    try { u = new URL(a.href, location.href); } catch (e) { continue; }
+    if (u.origin !== here) continue;
+    u.hash = "";
+    const key = u.href.replace(/\/$/, "");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push(u.href);
+  }
+  return {
+    final_url: location.href,
+    title: clean(document.title),
+    description: clean(meta ? meta.getAttribute("content") : ""),
+    headings: Array.from(document.querySelectorAll("h1, h2, h3"))
+      .map((e) => clean(e.textContent)).filter(Boolean).slice(0, 15),
+    link_count: document.querySelectorAll("a[href]").length,
+    links: links.slice(0, 40),
+  };
+});
+"""
+
+
+def acceptable(url, visited):
+    """True if `url` is worth crawling (same-site content we have not seen)."""
+    if url.rstrip("/") in visited:
+        return False
+    path = urlparse(url).path.lower()
+    segments = [s for s in path.split("/") if s]
+    if any(seg in SKIP_SEGMENTS for seg in segments):
+        return False
+    return not path.endswith(SKIP_SUFFIXES)
+
+
+def safe_name(name):
+    """Filesystem-safe slug for a seed name."""
+    return "".join(c if c.isalnum() else "_" for c in name.lower())
+
+
+def main():
+    targets = json.loads(os.environ["TARGETS"])
+    links_per_seed = int(os.environ.get("LINKS_PER_SEED", "8"))
+    depth = int(os.environ.get("DEPTH", "2"))
+    level2_parents = int(os.environ.get("LEVEL2_PARENTS", "2"))
+    level2_links = int(os.environ.get("LEVEL2_LINKS", "3"))
+
+    os.makedirs(RESULT_DIR, exist_ok=True)
+    os.makedirs(SHOTS_DIR, exist_ok=True)
+
+    client = Kernel()
+    browser = client.browsers.create(stealth=True, timeout_seconds=1200)
+    session_id = browser.session_id
+    report = {
+        "session_id": session_id,
+        "live_view_url": browser.browser_live_view_url,
+        "sites": [],
+    }
+    pages_visited = 0
+    started = time.monotonic()
+
+    def extract(url):
+        resp = client.browsers.playwright.execute(
+            session_id,
+            code=EXTRACT_JS.replace("__URL__", json.dumps(url)),
+            timeout_sec=60,
+        )
+        if not resp.success:
+            raise RuntimeError(resp.error or "playwright.execute failed")
+        return resp.result
+
+    try:
+        for seed in targets:
+            print("seed " + seed["name"], flush=True)
+            site = {"name": seed["name"], "url": seed["url"]}
+            try:
+                home = extract(seed["url"])
+            except Exception as exc:
+                site["error"] = str(exc)[:200]
+                report["sites"].append(site)
+                print("  home failed: " + str(exc)[:80], flush=True)
+                continue
+            pages_visited += 1
+            site.update(
+                final_url=home["final_url"],
+                title=home["title"],
+                description=home["description"],
+                headings=home["headings"],
+                link_count=home["link_count"],
+                subpages=[],
+            )
+
+            # Screenshot the homepage now, before the crawl navigates away.
+            site["screenshot"] = None
+            try:
+                shot = client.browsers.computer.capture_screenshot(session_id)
+                shot_file = safe_name(seed["name"]) + ".png"
+                with open(os.path.join(SHOTS_DIR, shot_file), "wb") as fh:
+                    fh.write(shot.read())
+                site["screenshot"] = shot_file
+            except Exception as exc:
+                print("  screenshot failed: " + str(exc)[:80], flush=True)
+
+            visited = {home["final_url"].rstrip("/"), seed["url"].rstrip("/")}
+            level1 = [u for u in home.get("links", []) if acceptable(u, visited)][:links_per_seed]
+
+            for index, link in enumerate(level1):
+                if not acceptable(link, visited):
+                    continue
+                try:
+                    sub = extract(link)
+                except Exception as exc:
+                    print("  l1 failed: " + str(exc)[:60], flush=True)
+                    continue
+                pages_visited += 1
+                visited.add(sub["final_url"].rstrip("/"))
+                entry = {
+                    "url": sub["final_url"],
+                    "title": sub["title"],
+                    "headings": sub["headings"][:5],
+                    "subpages": [],
+                }
+                # Expand the first few level-1 pages one level deeper.
+                if depth >= 2 and index < level2_parents:
+                    level2 = [
+                        u for u in sub.get("links", []) if acceptable(u, visited)
+                    ][:level2_links]
+                    for deep_link in level2:
+                        if not acceptable(deep_link, visited):
+                            continue
+                        try:
+                            deep = extract(deep_link)
+                        except Exception as exc:
+                            print("    l2 failed: " + str(exc)[:50], flush=True)
+                            continue
+                        pages_visited += 1
+                        visited.add(deep["final_url"].rstrip("/"))
+                        entry["subpages"].append({"url": deep["final_url"], "title": deep["title"]})
+                        print("    ++ " + (deep["title"] or deep["final_url"])[:60], flush=True)
+                site["subpages"].append(entry)
+                print("  + " + (sub["title"] or sub["final_url"])[:64], flush=True)
+
+            report["sites"].append(site)
+    finally:
+        try:
+            client.browsers.delete_by_id(session_id)
+            print("browser released", flush=True)
+        except Exception as exc:
+            print("release failed: " + str(exc)[:80], flush=True)
+
+        # Always write results, so partial progress survives any single failure.
+        report["pages_visited"] = pages_visited
+        report["elapsed_seconds"] = round(time.monotonic() - started, 1)
+        with open(os.path.join(RESULT_DIR, "report.json"), "w") as fh:
+            json.dump(report, fh)
+
+        summary = {
+            "pages_visited": pages_visited,
+            "elapsed_seconds": report["elapsed_seconds"],
+            "live_view_url": report["live_view_url"],
+            "sites": [
+                {
+                    "name": s.get("name"),
+                    "title": s.get("title"),
+                    "headings": len(s.get("headings") or []),
+                    "subpages": len(s.get("subpages") or []),
+                    "screenshot": s.get("screenshot"),
+                    "error": s.get("error"),
+                }
+                for s in report["sites"]
+            ],
+        }
+        with open(os.path.join(RESULT_DIR, "summary.json"), "w") as fh:
+            json.dump(summary, fh)
+        print("wrote results", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/browser-integrations/kernel/python/kernel_runloop/agent.py
+++ b/browser-integrations/kernel/python/kernel_runloop/agent.py
@@ -7,7 +7,7 @@ structured data and a homepage screenshot per seed. Configuration is read from
 the environment, and results are written to files (no stdout protocol):
 
     TARGETS         JSON list of {"name", "url"}
-    LINKS_PER_SEED  level-1 internal links followed per seed (default 8)
+    LINKS_PER_SEED  level-1 internal links followed per seed (default 10)
     DEPTH           crawl depth, 1 or 2 (default 2)
     LEVEL2_PARENTS  how many level-1 pages to expand into level 2 (default 2)
     LEVEL2_LINKS    level-2 links per expanded parent (default 3)
@@ -88,7 +88,7 @@ def safe_name(name):
 
 def main():
     targets = json.loads(os.environ["TARGETS"])
-    links_per_seed = int(os.environ.get("LINKS_PER_SEED", "8"))
+    links_per_seed = int(os.environ.get("LINKS_PER_SEED", "10"))
     depth = int(os.environ.get("DEPTH", "2"))
     level2_parents = int(os.environ.get("LEVEL2_PARENTS", "2"))
     level2_links = int(os.environ.get("LEVEL2_LINKS", "3"))

--- a/browser-integrations/kernel/python/kernel_runloop/config.py
+++ b/browser-integrations/kernel/python/kernel_runloop/config.py
@@ -1,0 +1,40 @@
+"""Configuration for the Kernel-on-Runloop starter.
+
+Holds the blueprint definition, the default crawl targets, and a helper that
+loads the in-devbox agent source so it can be uploaded to a devbox at run time.
+"""
+
+from importlib import resources
+
+# Name of the blueprint that bakes the Kernel SDK into a devbox image.
+BLUEPRINT_NAME = "kernel-browser"
+
+# Commands run at blueprint build time. Installing the Kernel SDK here means a
+# devbox created from the blueprint starts ready, with no per-run install.
+# `--user` avoids PEP 668 ("externally-managed-environment") failures on the
+# base image.
+SYSTEM_SETUP_COMMANDS = ["python3 -m pip install --user kernel"]
+
+# Default sites the research agent crawls. Override via RunKernelOptions.targets.
+DEFAULT_TARGETS = [
+    {"name": "Runloop", "url": "https://runloop.ai"},
+    {"name": "Runloop Docs", "url": "https://docs.runloop.ai"},
+    {"name": "Kernel", "url": "https://kernel.sh"},
+    {"name": "Kernel Docs", "url": "https://www.kernel.sh/docs"},
+    {"name": "Hacker News", "url": "https://news.ycombinator.com"},
+    {"name": "Python Docs", "url": "https://docs.python.org/3/"},
+]
+
+# Default crawl breadth and depth.
+DEFAULT_LINKS_PER_SEED = 10
+DEFAULT_DEPTH = 2
+
+# Paths used inside the devbox.
+AGENT_REMOTE_PATH = "/home/user/agent.py"
+RESULT_DIR = "/home/user/result"
+SHOTS_DIR = "/home/user/shots"
+
+
+def load_agent_source() -> str:
+    """Return the source of the in-devbox crawl agent (`agent.py`)."""
+    return resources.files("kernel_runloop").joinpath("agent.py").read_text()

--- a/browser-integrations/kernel/python/kernel_runloop/create_blueprint.py
+++ b/browser-integrations/kernel/python/kernel_runloop/create_blueprint.py
@@ -1,0 +1,48 @@
+"""Create (or reuse) the Kernel blueprint.
+
+A blueprint bakes the Kernel SDK into a devbox image so that devboxes created
+from it start ready, with no per-run install. Building one takes ~40s, so this is
+a one-time step: by default it reuses the newest already-built `kernel-browser`
+blueprint and only builds when none exists. `run` then creates devboxes from the
+blueprint by name.
+"""
+
+from runloop_api_client import RunloopSDK
+
+from .config import BLUEPRINT_NAME, SYSTEM_SETUP_COMMANDS
+from .status import status
+
+
+def _existing_built_blueprint(runloop: RunloopSDK) -> str | None:
+    """Return the id of the newest built blueprint with our name, or None."""
+    built: list[tuple[int, str]] = []
+    for blueprint in runloop.blueprint.list(name=BLUEPRINT_NAME):
+        info = blueprint.get_info()
+        if info.status == "build_complete":
+            built.append((info.create_time_ms or 0, blueprint.id))
+    if not built:
+        return None
+    return max(built)[1]
+
+
+def create_kernel_blueprint(runloop: RunloopSDK | None = None, *, rebuild: bool = False) -> str:
+    """Return a built Kernel blueprint id, reusing an existing one unless rebuild=True.
+
+    Pass ``rebuild=True`` (CLI: ``create-blueprint --rebuild``) to force a fresh
+    build, e.g. after changing :data:`SYSTEM_SETUP_COMMANDS`.
+    """
+    runloop = runloop or RunloopSDK()
+
+    if not rebuild:
+        existing = _existing_built_blueprint(runloop)
+        if existing is not None:
+            status(f"Reusing built blueprint {existing} (skipping ~40s build; --rebuild to force)")
+            return existing
+
+    status(f"Building blueprint '{BLUEPRINT_NAME}' (this blocks until the image is built)")
+    blueprint = runloop.blueprint.create(
+        name=BLUEPRINT_NAME,
+        system_setup_commands=SYSTEM_SETUP_COMMANDS,
+    )
+    status("Blueprint build complete")
+    return blueprint.id

--- a/browser-integrations/kernel/python/kernel_runloop/provision.py
+++ b/browser-integrations/kernel/python/kernel_runloop/provision.py
@@ -1,0 +1,64 @@
+"""Provision a devbox with a bounded wait, failing fast on a stuck provision.
+
+The OO ``devbox.create`` waits for the devbox to reach ``running`` with an
+effectively unbounded default (120 attempts, no time cap), so a stuck provision
+hangs for many minutes with no feedback. :func:`provision_devbox` bounds that
+wait: on timeout, or if the devbox enters a terminal non-running state, it shuts
+the devbox down and raises, so a bad provision is loud and immediate instead of
+silent, and never leaks a half-provisioned (billable) devbox.
+"""
+
+import contextlib
+import secrets
+from typing import TYPE_CHECKING, Any
+
+from runloop_api_client import RunloopSDK
+from runloop_api_client.lib.polling import PollingConfig
+from runloop_api_client.sdk.devbox import Devbox
+
+if TYPE_CHECKING:
+    from runloop_api_client.types.shared_params.launch_parameters import LaunchParameters
+
+# How long to wait for a devbox to reach `running` before giving up.
+PROVISION_TIMEOUT_SECONDS = 120
+
+
+def unique_name(base: str) -> str:
+    """Append a random numeric slug so repeated runs do not stack identical devbox names."""
+    return f"{base}-{secrets.randbelow(9_000_000) + 1_000_000}"
+
+
+def provision_devbox(
+    runloop: RunloopSDK,
+    *,
+    name: str,
+    launch_parameters: "LaunchParameters",
+    environment_variables: dict[str, str] | None = None,
+    blueprint_name: str | None = None,
+) -> Devbox:
+    """Create a devbox and wait until it is running, or fail fast and clean up.
+
+    Returns a :class:`Devbox` (usable as a context manager). On a stuck or failed
+    provision it shuts the devbox down and raises :class:`RuntimeError`.
+    """
+    api = runloop.api
+    params: dict[str, Any] = {"name": name, "launch_parameters": launch_parameters}
+    if environment_variables is not None:
+        params["environment_variables"] = environment_variables
+    if blueprint_name is not None:
+        params["blueprint_name"] = blueprint_name
+
+    view = api.devboxes.create(**params)  # returns immediately, still provisioning
+    try:
+        api.devboxes.await_running(
+            view.id, polling_config=PollingConfig(timeout_seconds=PROVISION_TIMEOUT_SECONDS)
+        )
+    except Exception as exc:
+        # Don't leave a half-provisioned, billable devbox stuck; shut it down.
+        with contextlib.suppress(Exception):
+            api.devboxes.shutdown(view.id)
+        raise RuntimeError(
+            f"devbox {view.id} did not reach running within "
+            f"{PROVISION_TIMEOUT_SECONDS}s ({exc}); it was shut down"
+        ) from exc
+    return runloop.devbox.from_id(view.id)

--- a/browser-integrations/kernel/python/kernel_runloop/run_kernel.py
+++ b/browser-integrations/kernel/python/kernel_runloop/run_kernel.py
@@ -1,0 +1,149 @@
+"""Run the Kernel research agent inside a Runloop devbox.
+
+Provisions a devbox (from the pre-built blueprint, or with a runtime install when
+``manual`` is set), uploads the crawl agent, drives a Kernel cloud browser via
+Playwright Execute, downloads the report and per-seed screenshots, and returns a
+typed result. The devbox is torn down automatically by the SDK context manager.
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
+
+from runloop_api_client import RunloopSDK
+from runloop_api_client.lib.polling import PollingConfig
+
+if TYPE_CHECKING:
+    from runloop_api_client.types.shared_params.launch_parameters import LaunchParameters
+
+from .config import (
+    AGENT_REMOTE_PATH,
+    BLUEPRINT_NAME,
+    DEFAULT_DEPTH,
+    DEFAULT_LINKS_PER_SEED,
+    DEFAULT_TARGETS,
+    RESULT_DIR,
+    SHOTS_DIR,
+    load_agent_source,
+)
+from .provision import provision_devbox, unique_name
+from .status import status
+
+# `cmd.exec` polls for completion with a 120s default; the crawl runs longer, so
+# widen the polling window (distinct from the per-request HTTP timeout).
+_CRAWL_POLLING = PollingConfig(interval_seconds=2.0, timeout_seconds=600)
+
+
+@dataclass
+class RunKernelOptions:
+    """Options for :func:`run_kernel`."""
+
+    manual: bool = False  # install the Kernel SDK at runtime instead of using the blueprint
+    targets: list[dict[str, str]] = field(default_factory=lambda: list(DEFAULT_TARGETS))
+    links_per_seed: int = DEFAULT_LINKS_PER_SEED
+    depth: int = DEFAULT_DEPTH
+    size: str = "SMALL"
+    snapshot: bool = False  # snapshot the devbox disk on success
+    output_dir: str = "."  # where report.json and screenshots/ are written locally
+
+
+@dataclass
+class RunKernelResult:
+    """Result of a crawl run."""
+
+    devbox_id: str
+    pages_visited: int
+    live_view_url: str | None
+    report_path: str
+    screenshots_dir: str
+
+
+def run_kernel(
+    options: RunKernelOptions | None = None,
+    runloop: RunloopSDK | None = None,
+) -> RunKernelResult:
+    """Provision a devbox, run the crawl agent against a Kernel browser, return results."""
+    options = options or RunKernelOptions()
+    runloop = runloop or RunloopSDK()
+
+    env = {
+        "KERNEL_API_KEY": os.environ["KERNEL_API_KEY"],
+        "TARGETS": json.dumps(options.targets),
+        "LINKS_PER_SEED": str(options.links_per_seed),
+        "DEPTH": str(options.depth),
+    }
+    launch = cast("LaunchParameters", {"resource_size_request": options.size})
+
+    devbox_name = unique_name("kernel-research")
+    if options.manual:
+        status("Provisioning devbox (Kernel SDK installed at runtime)")
+        devbox_cm = provision_devbox(
+            runloop, name=devbox_name, environment_variables=env, launch_parameters=launch
+        )
+    else:
+        status(f"Provisioning devbox from blueprint '{BLUEPRINT_NAME}'")
+        devbox_cm = provision_devbox(
+            runloop,
+            name=devbox_name,
+            environment_variables=env,
+            launch_parameters=launch,
+            blueprint_name=BLUEPRINT_NAME,
+        )
+
+    with devbox_cm as devbox:
+        if options.manual:
+            status("Installing Kernel SDK in the devbox")
+            install = devbox.cmd.exec(
+                "python3 -m pip install --user --quiet kernel", timeout=240
+            )
+            if not install.success:
+                raise RuntimeError("kernel install failed: " + (install.stderr() or "")[-300:])
+
+        # Upload the agent and run it. Results come back as files (not stdout),
+        # so there is no fragile stdout-parsing protocol.
+        status(f"Devbox {devbox.id} ready; uploading the crawl agent")
+        devbox.file.write(file_path=AGENT_REMOTE_PATH, contents=load_agent_source())
+        status("Crawling in the devbox (typically 2-3 min); browser runs on Kernel")
+        result = devbox.cmd.exec(
+            f"python3 {AGENT_REMOTE_PATH}", timeout=600, polling_config=_CRAWL_POLLING
+        )
+        if not result.success:
+            raise RuntimeError(
+                f"agent failed (exit {result.exit_code}): " + (result.stderr() or "")[-300:]
+            )
+
+        summary = json.loads(devbox.file.read(file_path=f"{RESULT_DIR}/summary.json"))
+        report = json.loads(devbox.file.read(file_path=f"{RESULT_DIR}/report.json"))
+
+        # Pull screenshots back as binary files (not base64-through-text).
+        shots_dir = os.path.join(options.output_dir, "screenshots")
+        os.makedirs(shots_dir, exist_ok=True)
+        shot_count = 0
+        for site in summary["sites"]:
+            shot = site.get("screenshot")
+            if not shot:
+                continue
+            data = devbox.file.download(path=f"{SHOTS_DIR}/{shot}")
+            with open(os.path.join(shots_dir, shot), "wb") as fh:
+                fh.write(data)
+            shot_count += 1
+        status(f"Downloaded report.json and {shot_count} screenshots")
+
+        report_path = os.path.join(options.output_dir, "report.json")
+        with open(report_path, "w") as fh:
+            json.dump(report, fh, indent=2)
+
+        if options.snapshot:
+            status("Snapshotting devbox disk")
+            devbox.snapshot_disk(name=f"kernel-research-{devbox.id}")
+
+        status("Tearing down devbox")
+
+        return RunKernelResult(
+            devbox_id=devbox.id,
+            pages_visited=summary["pages_visited"],
+            live_view_url=summary.get("live_view_url"),
+            report_path=report_path,
+            screenshots_dir=shots_dir,
+        )

--- a/browser-integrations/kernel/python/kernel_runloop/status.py
+++ b/browser-integrations/kernel/python/kernel_runloop/status.py
@@ -1,0 +1,16 @@
+"""Lightweight progress output for CLI runs.
+
+Writes timestamped phase lines to stderr so they show live while a command runs,
+keeping stdout reserved for the final structured result.
+"""
+
+import sys
+import time
+
+_START = time.monotonic()
+
+
+def status(message: str) -> None:
+    """Print one timestamped progress line to stderr."""
+    elapsed = time.monotonic() - _START
+    print(f"  [{elapsed:5.1f}s] {message}", file=sys.stderr, flush=True)

--- a/browser-integrations/kernel/python/main.py
+++ b/browser-integrations/kernel/python/main.py
@@ -1,0 +1,11 @@
+"""Entry point for the Kernel-on-Runloop example.
+
+Usage:
+    python main.py create-blueprint [--rebuild]
+    python main.py run [--manual] [--snapshot]
+"""
+
+from kernel_runloop.__main__ import main
+
+if __name__ == "__main__":
+    main()

--- a/browser-integrations/kernel/python/requirements.txt
+++ b/browser-integrations/kernel/python/requirements.txt
@@ -1,0 +1,2 @@
+runloop_api_client>=1.23.2
+kernel>=0.67.0

--- a/browser-integrations/kernel/typescript/README.md
+++ b/browser-integrations/kernel/typescript/README.md
@@ -1,0 +1,41 @@
+# Kernel on Runloop: TypeScript
+
+Drive [Kernel](https://www.kernel.sh) cloud browsers from [Runloop](https://runloop.ai) devboxes. The agent runs in a devbox; the browser runs on Kernel, driven server-side with Playwright Execute, so no Chromium runs in the devbox.
+
+The orchestrator is TypeScript (`@runloop/api-client`). The in-devbox agent is Python (`agent.py`, embedded verbatim in `src/config.ts`); the devbox runs it with `python3`.
+
+## Setup
+
+```bash
+npm install
+
+export RUNLOOP_API_KEY="your-key"
+export KERNEL_API_KEY="your-key"
+```
+
+## Usage
+
+```bash
+npm run create-blueprint   # one time (reused on later runs)
+npm run run-kernel         # research crawl
+```
+
+### Commands
+
+| Command | Description |
+| --- | --- |
+| `npm run create-blueprint` | Reuse an existing built blueprint, or build one (`-- --rebuild` forces a fresh build) |
+| `npm run run-kernel` | Research crawl (`-- --manual` skips the blueprint; `-- --snapshot` snapshots on success) |
+
+## Layout
+
+- `src/index.ts`: CLI entry point.
+- `src/config.ts`: blueprint and crawl config, and the embedded Python agent.
+- `src/run-kernel.ts`: the research crawl orchestrator.
+- `src/provision.ts`: bounded devbox provisioning. `src/status.ts`: progress output.
+
+## Development
+
+```bash
+npm run build   # tsc type-check + declaration emit
+```

--- a/browser-integrations/kernel/typescript/package-lock.json
+++ b/browser-integrations/kernel/typescript/package-lock.json
@@ -1,0 +1,1093 @@
+{
+  "name": "kernel-runloop",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kernel-runloop",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@onkernel/sdk": "^0.68.0",
+        "@runloop/api-client": "^1.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.10.1",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@onkernel/sdk": {
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@onkernel/sdk/-/sdk-0.68.0.tgz",
+      "integrity": "sha512-mTB/WX6eGem1Hv3/qCY9NhwzzEY1xN78YoM49RkdHelVeQoh5JVg15JD2rBjtIQ9hAe2Z7iz3edLn9ruMk7pMw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@runloop/api-client": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@runloop/api-client/-/api-client-1.24.0.tgz",
+      "integrity": "sha512-A/G9l2MlBz/u0Wr2RvCEJvh0+4Pn/8p15BTq9wQt3vEgEGLEk844+9bIKsfWbDvU/4JdRvIUND79Vu5qvKQzUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "tar": "^7.5.2",
+        "undici": "^7.26.0",
+        "uuidv7": "^1.0.2",
+        "zod": "^3.24.1"
+      }
+    },
+    "node_modules/@runloop/api-client/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@runloop/api-client/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/uuidv7": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-1.2.1.tgz",
+      "integrity": "sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "uuidv7": "cli.js"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/browser-integrations/kernel/typescript/package.json
+++ b/browser-integrations/kernel/typescript/package.json
@@ -10,8 +10,7 @@
     "build": "tsc",
     "dev": "tsx src/index.ts",
     "create-blueprint": "tsx src/index.ts create-blueprint",
-    "run-kernel": "tsx src/index.ts run",
-    "e2e": "tsx src/index.ts e2e"
+    "run-kernel": "tsx src/index.ts run"
   },
   "dependencies": {
     "@onkernel/sdk": "^0.68.0",

--- a/browser-integrations/kernel/typescript/package.json
+++ b/browser-integrations/kernel/typescript/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "kernel-runloop",
+  "version": "0.1.0",
+  "description": "Drive Kernel cloud browsers from Runloop devboxes.",
+  "type": "module",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx src/index.ts",
+    "create-blueprint": "tsx src/index.ts create-blueprint",
+    "run-kernel": "tsx src/index.ts run",
+    "e2e": "tsx src/index.ts e2e"
+  },
+  "dependencies": {
+    "@onkernel/sdk": "^0.68.0",
+    "@runloop/api-client": "^1.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/browser-integrations/kernel/typescript/src/config.ts
+++ b/browser-integrations/kernel/typescript/src/config.ts
@@ -60,7 +60,7 @@ structured data and a homepage screenshot per seed. Configuration is read from
 the environment, and results are written to files (no stdout protocol):
 
     TARGETS         JSON list of {"name", "url"}
-    LINKS_PER_SEED  level-1 internal links followed per seed (default 8)
+    LINKS_PER_SEED  level-1 internal links followed per seed (default 10)
     DEPTH           crawl depth, 1 or 2 (default 2)
     LEVEL2_PARENTS  how many level-1 pages to expand into level 2 (default 2)
     LEVEL2_LINKS    level-2 links per expanded parent (default 3)
@@ -141,7 +141,7 @@ def safe_name(name):
 
 def main():
     targets = json.loads(os.environ["TARGETS"])
-    links_per_seed = int(os.environ.get("LINKS_PER_SEED", "8"))
+    links_per_seed = int(os.environ.get("LINKS_PER_SEED", "10"))
     depth = int(os.environ.get("DEPTH", "2"))
     level2_parents = int(os.environ.get("LEVEL2_PARENTS", "2"))
     level2_links = int(os.environ.get("LEVEL2_LINKS", "3"))

--- a/browser-integrations/kernel/typescript/src/config.ts
+++ b/browser-integrations/kernel/typescript/src/config.ts
@@ -1,0 +1,281 @@
+/**
+ * Configuration for the Kernel-on-Runloop starter.
+ *
+ * Holds the blueprint definition, the default crawl targets, the in-devbox
+ * paths, and the in-devbox agent source. The agent is embedded verbatim as a
+ * string and uploaded to a devbox at run time; the devbox runs it with Python,
+ * so the agent source stays Python regardless of this orchestrator being
+ * TypeScript.
+ */
+
+/** Name of the blueprint that bakes the Kernel SDK into a devbox image. */
+export const BLUEPRINT_NAME = "kernel-browser";
+
+/**
+ * Commands run at blueprint build time. Installing the Kernel SDK here means a
+ * devbox created from the blueprint starts ready, with no per-run install.
+ * `--user` avoids PEP 668 ("externally-managed-environment") failures on the
+ * base image.
+ */
+export const SYSTEM_SETUP_COMMANDS: string[] = ["python3 -m pip install --user kernel"];
+
+/** A single crawl seed. */
+export interface Target {
+  name: string;
+  url: string;
+}
+
+/** Default sites the research agent crawls. Override via RunKernelOptions.targets. */
+export const DEFAULT_TARGETS: Target[] = [
+  { name: "Runloop", url: "https://runloop.ai" },
+  { name: "Runloop Docs", url: "https://docs.runloop.ai" },
+  { name: "Kernel", url: "https://kernel.sh" },
+  { name: "Kernel Docs", url: "https://www.kernel.sh/docs" },
+  { name: "Hacker News", url: "https://news.ycombinator.com" },
+  { name: "Python Docs", url: "https://docs.python.org/3/" },
+];
+
+/** Default crawl breadth and depth. */
+export const DEFAULT_LINKS_PER_SEED = 10;
+export const DEFAULT_DEPTH = 2;
+
+/** Paths used inside the devbox. */
+export const AGENT_REMOTE_PATH = "/home/user/agent.py";
+export const RESULT_DIR = "/home/user/result";
+export const SHOTS_DIR = "/home/user/shots";
+
+/**
+ * Source of the in-devbox crawl agent (`agent.py`), embedded verbatim.
+ *
+ * This is Python: it is written to the devbox and executed there with
+ * `python3`. It is never imported or run by this TypeScript package; the
+ * orchestrator only uploads it and runs it inside the devbox.
+ */
+export const AGENT_SCRIPT = `"""In-devbox research agent.
+
+This module is uploaded into a Runloop devbox and run there (it is not imported
+by the rest of the package). It drives a single Kernel cloud browser via
+Playwright Execute to crawl a set of seed sites two levels deep, extracting
+structured data and a homepage screenshot per seed. Configuration is read from
+the environment, and results are written to files (no stdout protocol):
+
+    TARGETS         JSON list of {"name", "url"}
+    LINKS_PER_SEED  level-1 internal links followed per seed (default 8)
+    DEPTH           crawl depth, 1 or 2 (default 2)
+    LEVEL2_PARENTS  how many level-1 pages to expand into level 2 (default 2)
+    LEVEL2_LINKS    level-2 links per expanded parent (default 3)
+
+Outputs:
+    /home/user/result/report.json    full structured report
+    /home/user/result/summary.json   compact summary
+    /home/user/shots/<seed>.png      one homepage screenshot per seed
+"""
+
+import json
+import os
+import time
+from urllib.parse import urlparse
+
+from kernel import Kernel
+
+RESULT_DIR = "/home/user/result"
+SHOTS_DIR = "/home/user/shots"
+
+# Link paths we never follow (auth flows and non-content endpoints).
+SKIP_SEGMENTS = {
+    "login", "signin", "sign-in", "signup", "sign-up", "logout", "sign-out",
+    "account", "auth", "oauth", "cart", "checkout", "register", "admin",
+}
+SKIP_SUFFIXES = (".txt", ".xml", ".json", ".pdf", ".zip", ".png", ".jpg", ".svg", ".rss", ".ico")
+
+# Playwright snippet (JavaScript) run server-side on Kernel. It navigates, waits
+# for the network to settle so client-rendered content is present, then returns
+# structured data. \`__URL__\` is replaced per call.
+EXTRACT_JS = r"""
+await page.goto(__URL__, { waitUntil: "domcontentloaded", timeout: 20000 });
+await page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+return await page.evaluate(() => {
+  const clean = (s) => (s || "").replace(/\\s+/g, " ").trim();
+  const meta = document.querySelector('meta[name="description"]');
+  const here = location.origin;
+  const links = [];
+  const seen = new Set();
+  for (const a of document.querySelectorAll("a[href]")) {
+    let u;
+    try { u = new URL(a.href, location.href); } catch (e) { continue; }
+    if (u.origin !== here) continue;
+    u.hash = "";
+    const key = u.href.replace(/\\/$/, "");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    links.push(u.href);
+  }
+  return {
+    final_url: location.href,
+    title: clean(document.title),
+    description: clean(meta ? meta.getAttribute("content") : ""),
+    headings: Array.from(document.querySelectorAll("h1, h2, h3"))
+      .map((e) => clean(e.textContent)).filter(Boolean).slice(0, 15),
+    link_count: document.querySelectorAll("a[href]").length,
+    links: links.slice(0, 40),
+  };
+});
+"""
+
+
+def acceptable(url, visited):
+    """True if \`url\` is worth crawling (same-site content we have not seen)."""
+    if url.rstrip("/") in visited:
+        return False
+    path = urlparse(url).path.lower()
+    segments = [s for s in path.split("/") if s]
+    if any(seg in SKIP_SEGMENTS for seg in segments):
+        return False
+    return not path.endswith(SKIP_SUFFIXES)
+
+
+def safe_name(name):
+    """Filesystem-safe slug for a seed name."""
+    return "".join(c if c.isalnum() else "_" for c in name.lower())
+
+
+def main():
+    targets = json.loads(os.environ["TARGETS"])
+    links_per_seed = int(os.environ.get("LINKS_PER_SEED", "8"))
+    depth = int(os.environ.get("DEPTH", "2"))
+    level2_parents = int(os.environ.get("LEVEL2_PARENTS", "2"))
+    level2_links = int(os.environ.get("LEVEL2_LINKS", "3"))
+
+    os.makedirs(RESULT_DIR, exist_ok=True)
+    os.makedirs(SHOTS_DIR, exist_ok=True)
+
+    client = Kernel()
+    browser = client.browsers.create(stealth=True, timeout_seconds=1200)
+    session_id = browser.session_id
+    report = {
+        "session_id": session_id,
+        "live_view_url": browser.browser_live_view_url,
+        "sites": [],
+    }
+    pages_visited = 0
+    started = time.monotonic()
+
+    def extract(url):
+        resp = client.browsers.playwright.execute(
+            session_id,
+            code=EXTRACT_JS.replace("__URL__", json.dumps(url)),
+            timeout_sec=60,
+        )
+        if not resp.success:
+            raise RuntimeError(resp.error or "playwright.execute failed")
+        return resp.result
+
+    try:
+        for seed in targets:
+            print("seed " + seed["name"], flush=True)
+            site = {"name": seed["name"], "url": seed["url"]}
+            try:
+                home = extract(seed["url"])
+            except Exception as exc:
+                site["error"] = str(exc)[:200]
+                report["sites"].append(site)
+                print("  home failed: " + str(exc)[:80], flush=True)
+                continue
+            pages_visited += 1
+            site.update(
+                final_url=home["final_url"],
+                title=home["title"],
+                description=home["description"],
+                headings=home["headings"],
+                link_count=home["link_count"],
+                subpages=[],
+            )
+
+            # Screenshot the homepage now, before the crawl navigates away.
+            site["screenshot"] = None
+            try:
+                shot = client.browsers.computer.capture_screenshot(session_id)
+                shot_file = safe_name(seed["name"]) + ".png"
+                with open(os.path.join(SHOTS_DIR, shot_file), "wb") as fh:
+                    fh.write(shot.read())
+                site["screenshot"] = shot_file
+            except Exception as exc:
+                print("  screenshot failed: " + str(exc)[:80], flush=True)
+
+            visited = {home["final_url"].rstrip("/"), seed["url"].rstrip("/")}
+            level1 = [u for u in home.get("links", []) if acceptable(u, visited)][:links_per_seed]
+
+            for index, link in enumerate(level1):
+                if not acceptable(link, visited):
+                    continue
+                try:
+                    sub = extract(link)
+                except Exception as exc:
+                    print("  l1 failed: " + str(exc)[:60], flush=True)
+                    continue
+                pages_visited += 1
+                visited.add(sub["final_url"].rstrip("/"))
+                entry = {
+                    "url": sub["final_url"],
+                    "title": sub["title"],
+                    "headings": sub["headings"][:5],
+                    "subpages": [],
+                }
+                # Expand the first few level-1 pages one level deeper.
+                if depth >= 2 and index < level2_parents:
+                    level2 = [
+                        u for u in sub.get("links", []) if acceptable(u, visited)
+                    ][:level2_links]
+                    for deep_link in level2:
+                        if not acceptable(deep_link, visited):
+                            continue
+                        try:
+                            deep = extract(deep_link)
+                        except Exception as exc:
+                            print("    l2 failed: " + str(exc)[:50], flush=True)
+                            continue
+                        pages_visited += 1
+                        visited.add(deep["final_url"].rstrip("/"))
+                        entry["subpages"].append({"url": deep["final_url"], "title": deep["title"]})
+                        print("    ++ " + (deep["title"] or deep["final_url"])[:60], flush=True)
+                site["subpages"].append(entry)
+                print("  + " + (sub["title"] or sub["final_url"])[:64], flush=True)
+
+            report["sites"].append(site)
+    finally:
+        try:
+            client.browsers.delete_by_id(session_id)
+            print("browser released", flush=True)
+        except Exception as exc:
+            print("release failed: " + str(exc)[:80], flush=True)
+
+        # Always write results, so partial progress survives any single failure.
+        report["pages_visited"] = pages_visited
+        report["elapsed_seconds"] = round(time.monotonic() - started, 1)
+        with open(os.path.join(RESULT_DIR, "report.json"), "w") as fh:
+            json.dump(report, fh)
+
+        summary = {
+            "pages_visited": pages_visited,
+            "elapsed_seconds": report["elapsed_seconds"],
+            "live_view_url": report["live_view_url"],
+            "sites": [
+                {
+                    "name": s.get("name"),
+                    "title": s.get("title"),
+                    "headings": len(s.get("headings") or []),
+                    "subpages": len(s.get("subpages") or []),
+                    "screenshot": s.get("screenshot"),
+                    "error": s.get("error"),
+                }
+                for s in report["sites"]
+            ],
+        }
+        with open(os.path.join(RESULT_DIR, "summary.json"), "w") as fh:
+            json.dump(summary, fh)
+        print("wrote results", flush=True)
+
+
+if __name__ == "__main__":
+    main()
+`;

--- a/browser-integrations/kernel/typescript/src/create-blueprint.ts
+++ b/browser-integrations/kernel/typescript/src/create-blueprint.ts
@@ -1,0 +1,66 @@
+/**
+ * Create (or reuse) the Kernel blueprint.
+ *
+ * A blueprint bakes the Kernel SDK into a devbox image so that devboxes created
+ * from it start ready, with no per-run install. Building one takes ~40s, so this
+ * is a one-time step: by default it reuses the newest already-built
+ * `kernel-browser` blueprint and only builds when none exists. `run` then creates
+ * devboxes from the blueprint by name.
+ */
+
+import { RunloopSDK } from "@runloop/api-client";
+
+import { BLUEPRINT_NAME, SYSTEM_SETUP_COMMANDS } from "./config.js";
+import { status } from "./status.js";
+
+/** Options for {@link createKernelBlueprint}. */
+export interface CreateBlueprintOptions {
+  /** Force a fresh build even when a built blueprint already exists. */
+  rebuild?: boolean;
+}
+
+/** Return the id of the newest built blueprint with our name, or null. */
+async function existingBuiltBlueprint(sdk: RunloopSDK): Promise<string | null> {
+  let best: { ts: number; id: string } | null = null;
+  for (const blueprint of await sdk.blueprint.list({ name: BLUEPRINT_NAME })) {
+    const info = await blueprint.getInfo();
+    if (info.status === "build_complete" && (best === null || info.create_time_ms > best.ts)) {
+      best = { ts: info.create_time_ms, id: blueprint.id };
+    }
+  }
+  return best?.id ?? null;
+}
+
+/**
+ * Return a built Kernel blueprint id, reusing an existing one unless
+ * `options.rebuild` is set.
+ *
+ * Pass `{ rebuild: true }` (CLI: `create-blueprint --rebuild`) to force a fresh
+ * build, e.g. after changing {@link SYSTEM_SETUP_COMMANDS}.
+ *
+ * @param runloop - Optional pre-configured SDK instance (mainly for testing).
+ * @param options - See {@link CreateBlueprintOptions}.
+ * @returns The id of a built blueprint.
+ */
+export async function createKernelBlueprint(
+  runloop?: RunloopSDK,
+  options: CreateBlueprintOptions = {},
+): Promise<string> {
+  const sdk = runloop ?? new RunloopSDK();
+
+  if (!options.rebuild) {
+    const existing = await existingBuiltBlueprint(sdk);
+    if (existing !== null) {
+      status(`Reusing built blueprint ${existing} (skipping ~40s build; --rebuild to force)`);
+      return existing;
+    }
+  }
+
+  status(`Building blueprint '${BLUEPRINT_NAME}' (this blocks until the image is built)`);
+  const blueprint = await sdk.blueprint.create({
+    name: BLUEPRINT_NAME,
+    system_setup_commands: SYSTEM_SETUP_COMMANDS,
+  });
+  status("Blueprint build complete");
+  return blueprint.id;
+}

--- a/browser-integrations/kernel/typescript/src/index.ts
+++ b/browser-integrations/kernel/typescript/src/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Kernel on Runloop: drive Kernel cloud browsers from Runloop devboxes.
+ *
+ * Public API re-exports plus a small CLI:
+ *
+ *     kernel-runloop create-blueprint [--rebuild]   reuse or build the Kernel blueprint
+ *     kernel-runloop run [--manual] [--snapshot]    run the research crawl
+ */
+
+import { createKernelBlueprint } from "./create-blueprint.js";
+import { type RunKernelOptions, type RunKernelResult, runKernel } from "./run-kernel.js";
+
+export { BLUEPRINT_NAME, DEFAULT_TARGETS } from "./config.js";
+export type { Target } from "./config.js";
+export { createKernelBlueprint } from "./create-blueprint.js";
+export { runKernel } from "./run-kernel.js";
+export type { RunKernelOptions, RunKernelResult } from "./run-kernel.js";
+
+const USAGE = "Usage: kernel-runloop {create-blueprint [--rebuild] | run [--manual] [--snapshot]}";
+
+/** CLI entry point. Dispatches on the first positional argument. */
+export async function main(): Promise<void> {
+  const command = process.argv[2];
+  const flags = process.argv.slice(3);
+
+  switch (command) {
+    case "create-blueprint": {
+      const blueprintId = await createKernelBlueprint(undefined, {
+        rebuild: flags.includes("--rebuild"),
+      });
+      console.log(`Blueprint ready: ${blueprintId}`);
+      break;
+    }
+    case "run": {
+      const options: RunKernelOptions = {
+        manual: flags.includes("--manual"),
+        snapshot: flags.includes("--snapshot"),
+      };
+      const result: RunKernelResult = await runKernel(options);
+      console.log(`Devbox ${result.devboxId} crawled ${result.pagesVisited} pages`);
+      console.log(`Report: ${result.reportPath}`);
+      if (result.liveViewUrl) {
+        console.log(`Live view: ${result.liveViewUrl}`);
+      }
+      break;
+    }
+    default:
+      console.log(USAGE);
+  }
+}
+
+// Self-run guard: only execute the CLI when this module is the entry point.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/browser-integrations/kernel/typescript/src/index.ts
+++ b/browser-integrations/kernel/typescript/src/index.ts
@@ -45,7 +45,8 @@ export async function main(): Promise<void> {
       break;
     }
     default:
-      console.log(USAGE);
+      console.error(USAGE);
+      process.exitCode = 1;
   }
 }
 

--- a/browser-integrations/kernel/typescript/src/provision.ts
+++ b/browser-integrations/kernel/typescript/src/provision.ts
@@ -1,0 +1,46 @@
+/**
+ * Provision a devbox with a bounded wait, failing fast on a stuck provision.
+ *
+ * The OO `devbox.create` waits for the devbox to reach `running` with an
+ * effectively unbounded default, so a stuck provision hangs for many minutes
+ * with no feedback. `provisionDevbox` bounds that wait: on timeout, or if the
+ * devbox enters a terminal non-running state, it shuts the devbox down and
+ * throws, so a bad provision is loud and immediate instead of silent, and never
+ * leaks a half-provisioned (billable) devbox.
+ */
+
+import type { Devbox, Runloop, RunloopSDK } from "@runloop/api-client";
+
+/** How long to wait for a devbox to reach `running` before giving up. */
+const PROVISION_TIMEOUT_MS = 120_000;
+
+/** Append a random numeric slug so repeated runs do not stack identical devbox names. */
+export function uniqueName(base: string): string {
+  return `${base}-${Math.floor(1_000_000 + Math.random() * 9_000_000)}`;
+}
+
+/**
+ * Create a devbox and wait until it is running, or fail fast and clean up.
+ *
+ * @param sdk - The Runloop SDK instance.
+ * @param params - Devbox create parameters (name, launch_parameters, blueprint_name, ...).
+ * @returns A {@link Devbox} bound to the running devbox.
+ */
+export async function provisionDevbox(
+  sdk: RunloopSDK,
+  params: Runloop.DevboxCreateParams,
+): Promise<Devbox> {
+  const view = await sdk.api.devboxes.create(params); // returns immediately, still provisioning
+  try {
+    await sdk.api.devboxes.awaitRunning(view.id, { longPoll: { timeoutMs: PROVISION_TIMEOUT_MS } });
+  } catch (err) {
+    // Don't leave a half-provisioned, billable devbox stuck; shut it down.
+    await sdk.api.devboxes.shutdown(view.id).catch(() => {});
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `devbox ${view.id} did not reach running within ${PROVISION_TIMEOUT_MS / 1000}s ` +
+        `(${detail}); it was shut down`,
+    );
+  }
+  return sdk.devbox.fromId(view.id);
+}

--- a/browser-integrations/kernel/typescript/src/run-kernel.ts
+++ b/browser-integrations/kernel/typescript/src/run-kernel.ts
@@ -1,0 +1,197 @@
+/**
+ * Run the Kernel research agent inside a Runloop devbox.
+ *
+ * Provisions a devbox (from the pre-built blueprint, or with a runtime install
+ * when `manual` is set), uploads the crawl agent, drives a Kernel cloud browser
+ * via Playwright Execute, downloads the report and per-seed screenshots, and
+ * returns a typed result. The devbox is always torn down in a `finally` block.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { type Devbox, RunloopSDK } from "@runloop/api-client";
+import type { Runloop } from "@runloop/api-client";
+
+import {
+  AGENT_REMOTE_PATH,
+  AGENT_SCRIPT,
+  BLUEPRINT_NAME,
+  DEFAULT_DEPTH,
+  DEFAULT_LINKS_PER_SEED,
+  DEFAULT_TARGETS,
+  RESULT_DIR,
+  SHOTS_DIR,
+  type Target,
+} from "./config.js";
+import { provisionDevbox, uniqueName } from "./provision.js";
+import { status } from "./status.js";
+
+/**
+ * The crawl runs longer than the SDK's default long-poll window, so widen it.
+ * In the Python half this is a `PollingConfig(timeout_seconds=600)`; the TS SDK
+ * expresses the same idea as `longPoll.timeoutMs`.
+ */
+const CRAWL_TIMEOUT_MS = 600_000;
+
+/** Resource size accepted by the Runloop API (`launch_parameters.resource_size_request`). */
+type ResourceSize = NonNullable<Runloop.LaunchParameters["resource_size_request"]>;
+
+/** Options for {@link runKernel}. */
+export interface RunKernelOptions {
+  /** Install the Kernel SDK at runtime instead of using the blueprint. */
+  manual?: boolean;
+  /** Sites to crawl. Defaults to {@link DEFAULT_TARGETS}. */
+  targets?: Target[];
+  /** Level-1 internal links followed per seed. */
+  linksPerSeed?: number;
+  /** Crawl depth, 1 or 2. */
+  depth?: number;
+  /** Devbox resource size. */
+  size?: ResourceSize;
+  /** Snapshot the devbox disk on success. */
+  snapshot?: boolean;
+  /** Where report.json and screenshots/ are written locally. */
+  outputDir?: string;
+}
+
+/** Result of a crawl run. */
+export interface RunKernelResult {
+  devboxId: string;
+  pagesVisited: number;
+  liveViewUrl: string | null;
+  reportPath: string;
+  screenshotsDir: string;
+}
+
+/** Shape of the compact summary the in-devbox agent writes to summary.json. */
+interface CrawlSummary {
+  pages_visited: number;
+  live_view_url: string | null;
+  sites: Array<{ screenshot: string | null }>;
+}
+
+/**
+ * Provision a devbox, run the crawl agent against a Kernel browser, and return
+ * results. The devbox is torn down (shutdown) regardless of success or failure.
+ *
+ * @param options - Crawl options; see {@link RunKernelOptions}.
+ * @param runloop - Optional pre-configured SDK instance (mainly for testing).
+ */
+export async function runKernel(
+  options: RunKernelOptions = {},
+  runloop?: RunloopSDK,
+): Promise<RunKernelResult> {
+  const {
+    manual = false,
+    targets = DEFAULT_TARGETS,
+    linksPerSeed = DEFAULT_LINKS_PER_SEED,
+    depth = DEFAULT_DEPTH,
+    size = "SMALL",
+    snapshot = false,
+    outputDir = ".",
+  } = options;
+
+  const sdk = runloop ?? new RunloopSDK();
+
+  const apiKey = process.env.KERNEL_API_KEY;
+  if (!apiKey) {
+    throw new Error("KERNEL_API_KEY is not set");
+  }
+
+  const environment_variables = {
+    KERNEL_API_KEY: apiKey,
+    TARGETS: JSON.stringify(targets),
+    LINKS_PER_SEED: String(linksPerSeed),
+    DEPTH: String(depth),
+  };
+  const launch_parameters = { resource_size_request: size };
+
+  // Provision from the blueprint by name, or a default devbox for the manual path.
+  status(
+    manual
+      ? "Provisioning devbox (Kernel SDK installed at runtime)"
+      : `Provisioning devbox from blueprint '${BLUEPRINT_NAME}'`,
+  );
+  const devboxName = uniqueName("kernel-research");
+  const devbox: Devbox = manual
+    ? await provisionDevbox(sdk, {
+        name: devboxName,
+        environment_variables,
+        launch_parameters,
+      })
+    : await provisionDevbox(sdk, {
+        name: devboxName,
+        blueprint_name: BLUEPRINT_NAME,
+        environment_variables,
+        launch_parameters,
+      });
+
+  try {
+    if (manual) {
+      status("Installing Kernel SDK in the devbox");
+      const install = await devbox.cmd.exec("python3 -m pip install --user --quiet kernel");
+      if (!install.success) {
+        const stderr = await install.stderr();
+        throw new Error(`kernel install failed: ${stderr.slice(-300)}`);
+      }
+    }
+
+    // Upload the agent and run it. Results come back as files (not stdout), so
+    // there is no fragile stdout-parsing protocol.
+    status(`Devbox ${devbox.id} ready; uploading the crawl agent`);
+    await devbox.file.write({ file_path: AGENT_REMOTE_PATH, contents: AGENT_SCRIPT });
+    status("Crawling in the devbox (typically 2-3 min); browser runs on Kernel");
+    const result = await devbox.cmd.exec(`python3 ${AGENT_REMOTE_PATH}`, undefined, {
+      longPoll: { timeoutMs: CRAWL_TIMEOUT_MS },
+    });
+    if (!result.success) {
+      const stderr = await result.stderr();
+      throw new Error(`agent failed (exit ${result.exitCode}): ${stderr.slice(-300)}`);
+    }
+
+    const summary = JSON.parse(
+      await devbox.file.read({ file_path: `${RESULT_DIR}/summary.json` }),
+    ) as CrawlSummary;
+    const report = JSON.parse(
+      await devbox.file.read({ file_path: `${RESULT_DIR}/report.json` }),
+    ) as unknown;
+
+    // Pull screenshots back as binary files (not base64-through-text).
+    const shotsDir = path.join(outputDir, "screenshots");
+    await mkdir(shotsDir, { recursive: true });
+    let shotCount = 0;
+    for (const site of summary.sites) {
+      const shot = site.screenshot;
+      if (!shot) {
+        continue;
+      }
+      const response = await devbox.file.download({ path: `${SHOTS_DIR}/${shot}` });
+      const data = Buffer.from(await response.arrayBuffer());
+      await writeFile(path.join(shotsDir, shot), data);
+      shotCount += 1;
+    }
+    status(`Downloaded report.json and ${shotCount} screenshots`);
+
+    const reportPath = path.join(outputDir, "report.json");
+    await writeFile(reportPath, JSON.stringify(report, null, 2));
+
+    if (snapshot) {
+      status("Snapshotting devbox disk");
+      await devbox.snapshotDisk({ name: `kernel-research-${devbox.id}` });
+    }
+
+    status("Tearing down devbox");
+    return {
+      devboxId: devbox.id,
+      pagesVisited: summary.pages_visited,
+      liveViewUrl: summary.live_view_url,
+      reportPath,
+      screenshotsDir: shotsDir,
+    };
+  } finally {
+    // The TS SDK has no context-manager teardown, so shut the devbox down
+    // explicitly. Swallow teardown errors so they never mask a real failure.
+    await devbox.shutdown().catch(() => {});
+  }
+}

--- a/browser-integrations/kernel/typescript/src/status.ts
+++ b/browser-integrations/kernel/typescript/src/status.ts
@@ -1,0 +1,14 @@
+/**
+ * Lightweight progress output for CLI runs.
+ *
+ * Writes timestamped phase lines to stderr so they show live while a command
+ * runs, keeping stdout reserved for the final structured result.
+ */
+
+const START = Date.now();
+
+/** Print one timestamped progress line to stderr. */
+export function status(message: string): void {
+  const elapsed = ((Date.now() - START) / 1000).toFixed(1).padStart(5);
+  process.stderr.write(`  [${elapsed}s] ${message}\n`);
+}

--- a/browser-integrations/kernel/typescript/tsconfig.json
+++ b/browser-integrations/kernel/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Kernel on Runloop: Full Runnable Example

Adds `kernel-browser/`, a dual-language example showing how a Runloop agent gets browser access via [Kernel](https://www.kernel.sh).

**Architecture:** the agent runs in a devbox and drives a Kernel cloud browser *server-side* through `browsers.playwright.execute`. No CDP and no Chromium in the devbox (it only needs the Kernel SDK).

Two patterns over the same primitives, in Python and TypeScript:
- **`run`**: Research agent in a devbox drives one Kernel browser to crawl seed sites and return structured data plus screenshots.
- **`e2e`**: Devbox hosts an app behind a tunnel; a Kernel browser runs a real user flow against it (preview-testing pattern).

A blueprint bakes the Kernel SDK in, and provisioning is bounded (fail fast plus clean up on a stuck provision).

### Layout
- `kernel-browser/python/`: `requirements.txt` + `main.py` + `kernel_runloop/` package; run `python main.py {create-blueprint | run | e2e}`
- `kernel-browser/typescript/`: `package.json` + `src/`; run `npm run {create-blueprint | run-kernel | e2e}`
- Registered in the Add-ons table of the root README.

### Verified
- Python runs from `requirements.txt` (module imports + in-devbox agent load OK).
- TypeScript: `tsc` clean and `biome check` clean; the embedded Python agent in `config.ts` is byte-identical to `python/kernel_runloop/agent.py`.
- Reviewed all content by running docs repo locally. All formatting checks out.

Companion to the docs PR runloopai/docs#234.
