### PR TITLE
Kernel example: require Python 3.12+, fix stale tutorial reference

### DIFF
--- a/browser-integrations/kernel/README.md
+++ b/browser-integrations/kernel/README.md
@@ -2,7 +2,7 @@
 
 Give a Runloop agent browser access with [Kernel](https://www.kernel.sh): the agent runs in a devbox, the browser runs on Kernel, and the devbox drives it server-side with Playwright Execute, so no Chromium ever runs in the devbox.
 
-This is the runnable companion to the [Kernel on Runloop](https://docs.runloop.ai/docs/tutorials/kernel-runloop) tutorial and cookbook recipes.
+This is the runnable companion to the [Kernel on Runloop](https://docs.runloop.ai/docs/tutorials/kernel-runloop) tutorial.
 
 ## What's here
 
@@ -14,6 +14,8 @@ A **research crawl** (`run`), in both Python and TypeScript: a research agent in
 | TypeScript | [`typescript/`](typescript/) | `npm run {create-blueprint \| run-kernel}` |
 
 ## Setup
+
+The Python example needs Python 3.12+; the TypeScript example needs Node.js 18+.
 
 Both versions need two API keys:
 

--- a/browser-integrations/kernel/python/README.md
+++ b/browser-integrations/kernel/python/README.md
@@ -4,6 +4,8 @@ Drive [Kernel](https://www.kernel.sh) cloud browsers from [Runloop](https://runl
 
 ## Setup
 
+Requires Python 3.12+.
+
 ```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
Follow-up to #18.

- State the Python floor as 3.12+ in the kernel README and `python/README.md`. The example uses PEP 604 unions (`str | None`), which fail on Python 3.9; 3.12 matches the linux LTS default and the devbox image. Flagged by @tode-rl running the example on system python 3.9.6.
- Drop the stale "and cookbook recipes" reference: the docs consolidated the Kernel content into a single tutorial page.

No code change; the annotations are fine on 3.12.