### PR TITLE
Kernel example: fix TS screenshot download on gzipped responses

### DIFF
--- a/browser-integrations/kernel/typescript/src/run-kernel.ts
+++ b/browser-integrations/kernel/typescript/src/run-kernel.ts
@@ -166,7 +166,12 @@ export async function runKernel(
       if (!shot) {
         continue;
       }
-      const response = await devbox.file.download({ path: `${SHOTS_DIR}/${shot}` });
+      // Force identity encoding: the SDK's bundled node-fetch can throw
+      // ERR_STREAM_PREMATURE_CLOSE decompressing gzipped binary downloads on Node 18+.
+      const response = await devbox.file.download(
+        { path: `${SHOTS_DIR}/${shot}` },
+        { headers: { "Accept-Encoding": "identity" } },
+      );
       const data = Buffer.from(await response.arrayBuffer());
       await writeFile(path.join(shotsDir, shot), data);
       shotCount += 1;


### PR DESCRIPTION
The TypeScript run crashed at the screenshot download step with ERR_STREAM_PREMATURE_CLOSE: the Runloop SDK's bundled node-fetch throws when decompressing gzipped binary responses on Node 18+, so every run failed after the crawl completed. Request identity encoding on the download so the binary body is read without the broken gunzip path.