### PR TITLE
Kernel example: complete the file.read gzip fix + adjacent polling fixes

### DIFF
--- a/browser-integrations/kernel/python/kernel_runloop/provision.py
+++ b/browser-integrations/kernel/python/kernel_runloop/provision.py
@@ -19,8 +19,13 @@ from runloop_api_client.sdk.devbox import Devbox
 if TYPE_CHECKING:
     from runloop_api_client.types.shared_params.launch_parameters import LaunchParameters
 
-# How long to wait for a devbox to reach `running` before giving up.
-PROVISION_TIMEOUT_SECONDS = 120
+# Fail-fast ceiling: the most we wait for the devbox to reach `running` before
+# giving up and tearing it down. It returns the instant it is running (boot is
+# ~1-3s), so this is just a stuck-provision guard, not an expected boot time. Keep
+# it well under the crawl window so a bad provision fails quickly. (If you ever
+# raise it past ~120s, also bump `max_attempts` on the PollingConfig below, or the
+# default of 120 attempts caps the real wait regardless of this value.)
+PROVISION_TIMEOUT_SECONDS = 60
 
 
 def unique_name(base: str) -> str:

--- a/browser-integrations/kernel/python/kernel_runloop/run_kernel.py
+++ b/browser-integrations/kernel/python/kernel_runloop/run_kernel.py
@@ -30,9 +30,14 @@ from .config import (
 from .provision import provision_devbox, unique_name
 from .status import status
 
-# `cmd.exec` polls for completion with a 120s default; the crawl runs longer, so
-# widen the polling window (distinct from the per-request HTTP timeout).
-_CRAWL_POLLING = PollingConfig(interval_seconds=2.0, timeout_seconds=600)
+# `cmd.exec` polls for completion. The default PollingConfig caps `max_attempts` at
+# 120, so `timeout_seconds` alone does NOT widen the wait: at a 2s interval, polling
+# stops after ~120 attempts (~240s) regardless of `timeout_seconds`. Set `max_attempts`
+# high so `timeout_seconds` actually governs, and allow real headroom (the default-breadth
+# crawl runs several minutes). The HTTP `timeout` on `cmd.exec` is separate (per request).
+_CRAWL_POLLING = PollingConfig(interval_seconds=2.0, timeout_seconds=900, max_attempts=10000)
+# A cold `pip install` on the --manual path can exceed the default ~120s completion wait.
+_INSTALL_POLLING = PollingConfig(interval_seconds=2.0, timeout_seconds=300, max_attempts=10000)
 
 
 @dataclass
@@ -95,7 +100,9 @@ def run_kernel(
         if options.manual:
             status("Installing Kernel SDK in the devbox")
             install = devbox.cmd.exec(
-                "python3 -m pip install --user --quiet kernel", timeout=240
+                "python3 -m pip install --user --quiet kernel",
+                timeout=300,
+                polling_config=_INSTALL_POLLING,
             )
             if not install.success:
                 raise RuntimeError("kernel install failed: " + (install.stderr() or "")[-300:])
@@ -104,7 +111,7 @@ def run_kernel(
         # so there is no fragile stdout-parsing protocol.
         status(f"Devbox {devbox.id} ready; uploading the crawl agent")
         devbox.file.write(file_path=AGENT_REMOTE_PATH, contents=load_agent_source())
-        status("Crawling in the devbox (typically 2-3 min); browser runs on Kernel")
+        status("Crawling in the devbox (typically 3-5 min); browser runs on Kernel")
         result = devbox.cmd.exec(
             f"python3 {AGENT_REMOTE_PATH}", timeout=600, polling_config=_CRAWL_POLLING
         )

--- a/browser-integrations/kernel/typescript/src/provision.ts
+++ b/browser-integrations/kernel/typescript/src/provision.ts
@@ -11,8 +11,10 @@
 
 import type { Devbox, Runloop, RunloopSDK } from "@runloop/api-client";
 
-/** How long to wait for a devbox to reach `running` before giving up. */
-const PROVISION_TIMEOUT_MS = 120_000;
+/** Fail-fast ceiling: the most we wait for the devbox to reach `running` before
+ * giving up and tearing it down. It returns the instant it is running (boot is
+ * ~1-3s), so this is just a stuck-provision guard, not an expected boot time. */
+const PROVISION_TIMEOUT_MS = 60_000;
 
 /** Append a random numeric slug so repeated runs do not stack identical devbox names. */
 export function uniqueName(base: string): string {

--- a/browser-integrations/kernel/typescript/src/run-kernel.ts
+++ b/browser-integrations/kernel/typescript/src/run-kernel.ts
@@ -28,11 +28,12 @@ import { provisionDevbox, uniqueName } from "./provision.js";
 import { status } from "./status.js";
 
 /**
- * The crawl runs longer than the SDK's default long-poll window, so widen it.
- * In the Python half this is a `PollingConfig(timeout_seconds=600)`; the TS SDK
- * expresses the same idea as `longPoll.timeoutMs`.
+ * The crawl runs several minutes for the default breadth, so widen the long-poll
+ * window well past the SDK default. Kept in sync with the Python half
+ * (`PollingConfig(timeout_seconds=900)`); the TS SDK expresses the same idea as
+ * `longPoll.timeoutMs`, with no client-side max-attempts clamp to work around.
  */
-const CRAWL_TIMEOUT_MS = 600_000;
+const CRAWL_TIMEOUT_MS = 900_000;
 
 /** Resource size accepted by the Runloop API (`launch_parameters.resource_size_request`). */
 type ResourceSize = NonNullable<Runloop.LaunchParameters["resource_size_request"]>;
@@ -141,7 +142,7 @@ export async function runKernel(
     // there is no fragile stdout-parsing protocol.
     status(`Devbox ${devbox.id} ready; uploading the crawl agent`);
     await devbox.file.write({ file_path: AGENT_REMOTE_PATH, contents: AGENT_SCRIPT });
-    status("Crawling in the devbox (typically 2-3 min); browser runs on Kernel");
+    status("Crawling in the devbox (typically 3-5 min); browser runs on Kernel");
     const result = await devbox.cmd.exec(`python3 ${AGENT_REMOTE_PATH}`, undefined, {
       longPoll: { timeoutMs: CRAWL_TIMEOUT_MS },
     });
@@ -150,11 +151,20 @@ export async function runKernel(
       throw new Error(`agent failed (exit ${result.exitCode}): ${stderr.slice(-300)}`);
     }
 
+    // Same gzip class as the screenshot download below: file.read also flows through
+    // the bundled node-fetch + gunzip path, so a large gzipped JSON body can throw
+    // ERR_STREAM_PREMATURE_CLOSE on Node 18+. Force identity encoding here too.
     const summary = JSON.parse(
-      await devbox.file.read({ file_path: `${RESULT_DIR}/summary.json` }),
+      await devbox.file.read(
+        { file_path: `${RESULT_DIR}/summary.json` },
+        { headers: { "Accept-Encoding": "identity" } },
+      ),
     ) as CrawlSummary;
     const report = JSON.parse(
-      await devbox.file.read({ file_path: `${RESULT_DIR}/report.json` }),
+      await devbox.file.read(
+        { file_path: `${RESULT_DIR}/report.json` },
+        { headers: { "Accept-Encoding": "identity" } },
+      ),
     ) as unknown;
 
     // Pull screenshots back as binary files (not base64-through-text).


### PR DESCRIPTION
Follow-up to #22 by @rgarcia — thanks for catching the screenshot-download gzip crash. This lands the adjacent fixes the sweep surfaced (full detail in the #22 comment), validated end-to-end (a full crawl with all screenshots + both JSON reads, no `ERR_STREAM_PREMATURE_CLOSE`).

### Gzip class, completed
`devbox.file.read(...)` for `summary.json`/`report.json` flows through the same bundled node-fetch + gunzip path as the screenshot download #22 fixed, so a large gzipped JSON body can throw the same `ERR_STREAM_PREMATURE_CLOSE` on Node 18+. Same `Accept-Encoding: identity` treatment on both reads; @rgarcia's download fix is left exactly as merged.

### Polling `max_attempts` clamp (Python)
`PollingConfig`'s default `max_attempts=120` caps the wait at ~120 attempts regardless of `timeout_seconds`, so at a 2s interval the crawl wait was really ~240s (not 600s) — a longer crawl could get torn down mid-run. Set `max_attempts` high so `timeout_seconds` governs, gave the manual `pip install` its own completion poller, and raised the crawl window 600→900s for headroom (mirrored on the TS `longPoll.timeoutMs`).

### Provision fail-fast ceiling (120→60s)
The provision wait is a fail-fast ceiling — the most we wait for the devbox to reach `running` before giving up and tearing it down — not an expected boot time. Devboxes reach `running` in ~1–3s, so 60s is ample margin and a stuck provision now fails in 1 min instead of 2. (At 60s there is no `max_attempts` clamp to work around; the one-liner is back.)

### Cosmetic
Corrected the "2-3 min" crawl status string to "3-5 min" to match the real default-breadth runtime.

cc @rgarcia